### PR TITLE
python-fastjsonschema 2.15.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastjsonschema" %}
-{% set version = "2.15.1" %}
+{% set version = "2.15.3" %}
 
 package:
   name: python-{{ name }}
@@ -8,10 +8,10 @@ package:
 source:
   - folder: dist
     url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 671f36d225b3493629b5e789428660109528f373cf4b8a22bac6fa2f8191c2d2
+    sha256: 0a572f0836962d844c1fc435e200b2e4f4677e4e6611a2e3bdd01ba697c275ec
   - folder: src
     url: https://github.com/horejsek/python-{{ name }}/archive/v{{ version }}.tar.gz
-    sha256: 1a59d7ca91c90b79160ad43859caddb699cad07ddbb91c364a15b1b18f3a1fc4
+    sha256: 0a572f0836962d844c1fc435e200b2e4f4677e4e6611a2e3bdd01ba697c275ec
 
 build:
   noarch: python


### PR DESCRIPTION
Update python-fastjsonschema to 2.15.3