### PR TITLE
Update 2.16.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,14 +14,17 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
   script: cd dist && {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python >=3.3
+    - python
     - pip
+    - wheel
+    - setuptools
   run:
-    - python >=3.3
+    - python
 
 test:
   source_files:
@@ -44,6 +47,7 @@ about:
     fastjsonschema implements validation of JSON documents by JSON schema. The
     library implements JSON schema drafts 04, 06 and 07. The main purpose is to
     have a really fast implementation.
+  dev_url: https://github.com/horejsek/python-fastjsonschema
   doc_url: https://horejsek.github.io/python-fastjsonschema
   doc_source_url: https://github.com/horejsek/python-fastjsonschema/tree/master/docs
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,25 +1,21 @@
-{% set version = "2.16.1" %}
+{% set version = "2.16.2" %}
 
 package:
   name: python-fastjsonschema
   version: {{ version }}
 
 source:
-  - folder: dist
-    url: https://pypi.io/packages/source/f/fastjsonschema/fastjsonschema-{{ version }}.tar.gz
-    sha256: d6fa3ffbe719768d70e298b9fb847484e2bdfdb7241ed052b8d57a9294a8c334
-  - folder: src
-    url: https://github.com/horejsek/python-fastjsonschema/archive/v{{ version }}.tar.gz
-    sha256: 1acdf6bfaa4a16cbb5826f8abba40c6ac896a860c51b87edb2acbfb9462a2858
+  url: https://github.com/horejsek/python-fastjsonschema/archive/v{{ version }}.tar.gz
+  sha256: 552e8b07a076f4628e9a3c78f040ed673bed9b5b860d3cb51b323da50e2e3d47
 
 build:
   number: 0
   skip: True  # [py<36]
-  script: cd dist && {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python 
+    - python
     - pip
     - wheel
     - setuptools
@@ -28,14 +24,14 @@ requirements:
 
 test:
   source_files:
-    - src/tests
+    - tests
   requires:
     - pytest-cov
     - pytest-benchmark
   imports:
     - fastjsonschema
   commands:
-   - cd src && cd tests && pytest -vv --cov fastjsonschema -k "not (compile_to_code_ipv6_regex or compile_to_code_custom_format_with_refs)" --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 84
+   - cd tests && pytest -vv --cov fastjsonschema -k "not (compile_to_code_ipv6_regex or compile_to_code_custom_format_with_refs)" --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 84
 
 about:
   home: https://github.com/horejsek/python-fastjsonschema

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ about:
   home: https://github.com/horejsek/python-fastjsonschema
   license: BSD-3-Clause
   license_family: BSD
-  license_file: src/LICENSE
+  license_file: LICENSE
   summary: Fastest Python implementation of JSON schema
   description: |
     fastjsonschema implements validation of JSON documents by JSON schema. The

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,18 @@
-{% set name = "fastjsonschema" %}
-{% set version = "2.15.1" %}
+{% set version = "2.16.1" %}
 
 package:
-  name: python-{{ name }}
+  name: python-fastjsonschema
   version: {{ version }}
 
 source:
   - folder: dist
-    url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 671f36d225b3493629b5e789428660109528f373cf4b8a22bac6fa2f8191c2d2
+    url: https://pypi.io/packages/source/f/fastjsonschema/fastjsonschema-{{ version }}.tar.gz
+    sha256: d6fa3ffbe719768d70e298b9fb847484e2bdfdb7241ed052b8d57a9294a8c334
   - folder: src
-    url: https://github.com/horejsek/python-{{ name }}/archive/v{{ version }}.tar.gz
-    sha256: 1a59d7ca91c90b79160ad43859caddb699cad07ddbb91c364a15b1b18f3a1fc4
+    url: https://github.com/horejsek/python-fastjsonschema/archive/v{{ version }}.tar.gz
+    sha256: 1acdf6bfaa4a16cbb5826f8abba40c6ac896a860c51b87edb2acbfb9462a2858
 
 build:
-  noarch: python
   number: 0
   script: cd dist && {{ PYTHON }} -m pip install . -vv
 
@@ -34,7 +32,7 @@ test:
   imports:
     - fastjsonschema
   commands:
-    - cd src && cd tests && pytest --cov fastjsonschema -k "not compile_to_code_ipv6_regex"
+   - cd src && cd tests && pytest -vv --cov fastjsonschema -k "not (compile_to_code_ipv6_regex or compile_to_code_custom_format_with_refs)" --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 84
 
 about:
   home: https://github.com/horejsek/python-fastjsonschema

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 
 requirements:
   host:
-    - python
+    - python 
     - pip
     - wheel
     - setuptools


### PR DESCRIPTION
This is an update on the work from the previous pull request. 
https://github.com/AnacondaRecipes/python-fastjsonschema-feedstock/pull/3

Building 2.16.2 because the upstream maintainer released this version to address a failing test in 2.16.1.
https://github.com/horejsek/python-fastjsonschema/issues/154#issuecomment-1202109186